### PR TITLE
Capitalize the VERSIONS.txt url in the README.md

### DIFF
--- a/terradock/README.md
+++ b/terradock/README.md
@@ -8,7 +8,7 @@ This is influenced by: [alpine-docker/terragrunt](https://github.com/alpine-dock
 
 ## Versions
 There are multiple version combinations pushed to DockerHub.
-The different combinations can be found [here](./Versions.txt).
+The different combinations can be found [here](./VERSIONS.txt).
 The tags follow this pattern: `tf_<terraform_version>-tg_<terragrunt_version>`
 
 ***Note:** If you need a different combination of versions, open a PR or an Issue.*


### PR DESCRIPTION
## Expected Behavior
The link to `VERSIONS.txt` should work as intended inside of a web browser.

## Current Behavior
The link is currently broken and returns a `404 Not Found` error inside of a web browser.

## Solution
Capitalize the file name in the markdown code.